### PR TITLE
made autostart for Logistash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       timeout: 10s
       retries: 60
       start_period: 20s
+    restart: unless-stopped
     depends_on:
      - ospf-logstash-index-creator
     networks:


### PR DESCRIPTION
I found that the container doesn't start, although it should, because this is the only way to send or process logs.