### PR TITLE
README: list node role flag (ABR/ASBR) events

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OSPF Watcher is a monitoring tool of OSPF topology changes for network engineers
   * Maximum Reservable Link Bandwidth
   * Unreserved Bandwidth
   * Traffic Engineering Default Metric
+* OSPF node role flags: ABR/ASBR changes
 
 ## Architecture
 


### PR DESCRIPTION
The Watcher now tracks OSPF node role flags (ABR/ASBR, Router-LSA B/E bits) and emits a `node,changed` event, but the README's "Logged topology changes" list did not include it.

Adds one bullet to that list. README-only.

https://claude.ai/code/session_01Ruairr1dkMPPfdZw6hor1P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ruairr1dkMPPfdZw6hor1P)_